### PR TITLE
Not passing cameras and lights as arguments to Experiment constructor

### DIFF
--- a/cockpit/experiment/experiment.py
+++ b/cockpit/experiment/experiment.py
@@ -104,8 +104,6 @@ class Experiment:
     # \param altBottom Altitude of the stage at the bottom of the stack.
     # \param zHeight Total height of the stack.
     # \param sliceHeight Distance between slices in the stack.
-    # \param cameras List of CameraHandler instances.
-    # \param lights List of LightSourceHandler instances.
     # \param exposureSettings List of ([cameras], [(light, exposure time)])
     #        tuples describing how to take images.
     # \param otherHandlers List of miscellaneous handlers that are involved in
@@ -120,7 +118,7 @@ class Experiment:
     # *z* values refer to the position of the zPositioner specified in the args.
     def __init__(self, numReps, repDuration,
             zPositioner, altBottom, zHeight, sliceHeight,
-            cameras, lights, exposureSettings, otherHandlers = [],
+            exposureSettings, otherHandlers = [],
             metadata = '', savePath = ''):
         self.numReps = numReps
         self.repDuration = repDuration
@@ -128,9 +126,14 @@ class Experiment:
         self.altBottom = altBottom
         self.zHeight = zHeight
         self.sliceHeight = sliceHeight
-        self.cameras = list(cameras)
-        self.lights = list(lights)
         self.exposureSettings = exposureSettings
+
+        self.cameras = []
+        self.lights = []
+        for cameras, light_times in exposureSettings:
+            self.cameras.extend(cameras)
+            self.lights.extend([light for light, time in light_times])
+
         self.otherHandlers = list(otherHandlers)
         self.metadata = metadata
         self.savePath = savePath

--- a/cockpit/gui/dialogs/experiment/experimentConfigPanel.py
+++ b/cockpit/gui/dialogs/experiment/experimentConfigPanel.py
@@ -505,8 +505,6 @@ class ExperimentConfigPanel(wx.Panel):
                 'altBottom': altBottom,
                 'zHeight': zHeight,
                 'sliceHeight': sliceHeight,
-                'cameras': cameras,
-                'lights': lights,
                 'exposureSettings': exposureSettings,
                 'savePath': savePath
         }


### PR DESCRIPTION
These arguments are two lists, handlers to the cameras and lights required by the experiment.  However, these are already present on the `exposureSettings` arguments. This changes removes them.

I think this change breaks `immediateMode` but I can't find where immediate mode is used in cockpit to test it.